### PR TITLE
Add egg-info to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ doc/latex
 tags
 __pycache__
 BUILDS*
+*.egg-info


### PR DESCRIPTION
Egg-info folder is added with adding the package as editable in a python environment.

This pull request add that folder to gitignore